### PR TITLE
feat: add dark theme

### DIFF
--- a/app/_components/footer.tsx
+++ b/app/_components/footer.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
     <div className="border-t-2 mx-auto w-full max-w-2xl flex items-center justify-center m-2">
       <div className="flex items-center justify-center">
         <Link href="/">
-          <p className=" text-lg text-indigo-900 underline underline-offset-2">
+          <p className="text-lg text-indigo-900 underline underline-offset-2 dark:text-indigo-300">
             aman.sharma
           </p>
         </Link>

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -1,4 +1,8 @@
 import Link from "next/link";
+import ThemeToggle from "@/components/theme-toggle";
+
+const linkClass =
+  "md:text-lg underline underline-offset-2 text-indigo-900 dark:text-indigo-300";
 
 const Header = () => {
   return (
@@ -8,45 +12,32 @@ const Header = () => {
           {/* <div className="md:pb-4 pb-3 pt-1"> */}
           <div className="flex gap-2 items-center justify-center">
             <Link href="/">
-              <p className="md:text-lg text-indigo-900 font-bold underline underline-offset-2">
-                aman.sharma
-              </p>
+              <p className={`${linkClass} font-bold`}>aman.sharma</p>
             </Link>
           </div>
           <div className="flex gap-2 items-center justify-center">
             <div>
               <Link href="/about">
-                <p className="md:text-lg underline text-indigo-900 underline-offset-2">
-                  about
-                </p>
+                <p className={linkClass}>about</p>
               </Link>
             </div>
             <div>
-              <Link
-                href="/projects
-          "
-              >
-                <p className="md:text-lg underline text-indigo-900 underline-offset-2">
-                  projects
-                </p>
+              <Link href="/projects">
+                <p className={linkClass}>projects</p>
               </Link>
             </div>
             <div>
-              <Link
-                href="/experience
-          "
-              >
-                <p className="md:text-lg underline text-indigo-900 underline-offset-2">
-                  exp
-                </p>
+              <Link href="/experience">
+                <p className={linkClass}>exp</p>
               </Link>
             </div>
             <div>
               <Link href="/contact">
-                <p className="md:text-lg underline text-indigo-900 underline-offset-2">
-                  contact me
-                </p>
+                <p className={linkClass}>contact me</p>
               </Link>
+            </div>
+            <div>
+              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/app/_components/projects.tsx
+++ b/app/_components/projects.tsx
@@ -25,15 +25,15 @@ const ProjectsList: React.FC = () => {
   return (
     <div className="max-w-2xl mx-auto mt-2 mb-2 w-full h-full">
       <h2 className="text-4xl font-bold mb-3">View my work</h2>
-      <p className="text-black md:text-lg md:leading-5 leading-tight mb-3">links to projects here and elsewhere</p>
+      <p className="text-foreground md:text-lg md:leading-5 leading-tight mb-3">links to projects here and elsewhere</p>
       {projects.map((project, index) => (
         <div key={index} className="flex items-start mb-2">
-          <Dot size={32} className="flex-shrink-0" />
+          <Dot size={32} className="flex-shrink-0 text-indigo-900 dark:text-indigo-300" />
           <div>
-            <h3 className="text-black md:text-lg md:leading-5 leading-tight ">
-              <a href={project.link} className="text-indigo-900 underline">{project.name}</a>
+            <h3 className="text-foreground md:text-lg md:leading-5 leading-tight ">
+              <a href={project.link} className="text-indigo-900 underline dark:text-indigo-300">{project.name}</a>
             </h3>
-            <p className="text-black md:text-lg md:leading-5 leading-tight">{project.description}</p>
+            <p className="text-foreground md:text-lg md:leading-5 leading-tight">{project.description}</p>
           </div>
         </div>
       ))}

--- a/app/_components/technical.tsx
+++ b/app/_components/technical.tsx
@@ -18,10 +18,10 @@ const TechnicalSkill: React.FC = () => {
           <div key={index} className="flex items-start mb-2">
             <Dot size={32} className="flex-shrink-0" />
             <div>
-              <h3 className="text-black md:text-lg md:leading-5 leading-tight font-semibold">
+              <h3 className="text-foreground md:text-lg md:leading-5 leading-tight font-semibold">
                 {skill}
               </h3>
-              <p className="text-black md:text-lg text-sm md:leading-5 leading-tight">
+              <p className="text-foreground md:text-lg text-sm md:leading-5 leading-tight">
                 {skills[skill].join(' ')}
               </p>
             </div>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -21,41 +21,41 @@ const AboutMe: React.FC = () => {
           I&apos;ve built apps like <strong>ShareCode</strong> and <strong>Growing Buddies</strong>, and I&apos;m proficient in <strong>C++, Golang, React, Next.js, and modern web tech</strong>.
         </p>
         <p className="md:text-lg md:leading-5 leading-tight">
-          Here&apos;s a copy of my <a href="/Aman.pdf" className="text-indigo-900 underline" download>resume.</a>
+          Here&apos;s a copy of my <a href="/Aman.pdf" className="text-indigo-900 underline dark:text-indigo-300" download>resume.</a>
         </p>
       </section>
 
-      <hr className="my-2 border-gray-100" />
+      <hr className="my-2 border-gray-100 dark:border-gray-800" />
       <section className="mb-4">
         <h2 className="md:text-2xl text-xl  font-bold mb-1">Interests</h2>
         <p className="md:text-lg md:leading-5 leading-tight">
-          I enjoy graphic design, philosophical literature, origami, and calligraphy. I lead the design team for my university&apos;s fine arts society. Here&apos;s some <br /><a href="/about/interests" className="text-indigo-900 underline"> Stuff I Like</a>
+          I enjoy graphic design, philosophical literature, origami, and calligraphy. I lead the design team for my university&apos;s fine arts society. Here&apos;s some <br /><a href="/about/interests" className="text-indigo-900 underline dark:text-indigo-300"> Stuff I Like</a>
         </p>
       </section>
-      <hr className="my-2 border-gray-100" />
+      <hr className="my-2 border-gray-100 dark:border-gray-800" />
       <section className="mb-4">
         <h2 className="md:text-2xl text-xl font-bold mb-1">Find me online</h2>
         <div className="flex ml-8">
           <ul className="list-disc list-inside md:text-lg md:leading-5 leading-tight">
             <li>
-              I am <a href="https://github.com/aman1117" target="_blank" className="text-indigo-900 underline">aman1117</a> on GitHub
+              I am <a href="https://github.com/aman1117" target="_blank" className="text-indigo-900 underline dark:text-indigo-300">aman1117</a> on GitHub
             </li>
             <li>
-              I am <a href="https://leetcode.com/u/aman1117/" target="_blank" className="text-indigo-900 underline">aman1117</a> on Leetcode
+              I am <a href="https://leetcode.com/u/aman1117/" target="_blank" className="text-indigo-900 underline dark:text-indigo-300">aman1117</a> on Leetcode
             </li>
             <li>
-              I am <a href="https://codeforces.com/profile/aman1117" target="_blank" className="text-indigo-900 underline underline-offset-2">aman1117</a> on Codeforces
+              I am <a href="https://codeforces.com/profile/aman1117" target="_blank" className="text-indigo-900 underline underline-offset-2 dark:text-indigo-300">aman1117</a> on Codeforces
             </li>
             <li>
-              I am <a href="https://www.linkedin.com/in/aman1117/" target="_blank" className="text-indigo-900 underline">aman1117</a> on LinkedIn
+              I am <a href="https://www.linkedin.com/in/aman1117/" target="_blank" className="text-indigo-900 underline dark:text-indigo-300">aman1117</a> on LinkedIn
             </li>
             <li>
-              I am <a href="https://www.instagram.com/_aman1117_/" target="_blank" className="text-indigo-900 underline underline-offset-2">_aman1117_</a> on Instagram
+              I am <a href="https://www.instagram.com/_aman1117_/" target="_blank" className="text-indigo-900 underline underline-offset-2 dark:text-indigo-300">_aman1117_</a> on Instagram
             </li>
           </ul>
         </div>
       </section>
-      <hr className="my-2 border-gray-100" />
+      <hr className="my-2 border-gray-100 dark:border-gray-800" />
       <section className="mb-4">
         <h2 className="md:text-2xl text-xl font-bold mb-1">The Site</h2>
         <p className="md:text-lg md:leading-5 leading-tight">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -6,18 +6,17 @@ const ContactPage: React.FC = () => {
       <p className="text-4xl font-bold mb-3 mr-1">Contact Me</p>
       <div className="mb-4">
         <p className="md:text-lg">
-          <strong>Email:</strong> <a href="mailto:arl0817osho@gmail.com" className="text-indigo-900 underline underline-offset-2 ">arl0817osho@gmail.com</a>
+          <strong>Email:</strong> <a href="mailto:arl0817osho@gmail.com" className="text-indigo-900 underline underline-offset-2 dark:text-indigo-300">arl0817osho@gmail.com</a>
         </p>
         <p className="md:text-lg">
-          <strong>Contact Number:</strong> <a href="tel:+919873453266" className="text-indigo-900 underline underline-offset-2">+91 9873453266</a>
+          <strong>Contact Number:</strong> <a href="tel:+919873453266" className="text-indigo-900 underline underline-offset-2 dark:text-indigo-300">+91 9873453266</a>
         </p>
         <p className="md:text-lg">
-          <strong>Linkedin:</strong> <a href="https://www.linkedin.com/in/aman1117/" target="_blank" className="text-indigo-900 underline underline-offset-2">aman1117</a>
+          <strong>Linkedin:</strong> <a href="https://www.linkedin.com/in/aman1117/" target="_blank" className="text-indigo-900 underline underline-offset-2 dark:text-indigo-300">aman1117</a>
         </p>
       </div>
     </div>
   );
 };
-
 
 export default ContactPage;

--- a/app/experience/page.tsx
+++ b/app/experience/page.tsx
@@ -13,12 +13,12 @@ const ContactPage: React.FC = () => {
                     <p className="text-sm italic"><strong>June 2025 – Present</strong></p>
                     <p className="text-sm mb-4 italic"><strong>Bangalore, onsite</strong></p>
                     <ul className="list-disc list-inside mt-2 space-y-1">
-                        <li className="mb-2 text-black md:text-lg md:leading-5 leading-tight">
+                        <li className="mb-2 text-foreground md:text-lg md:leading-5 leading-tight">
                             Refactored and cleaned up backend redundant lags used for launching new feature using <strong>Optimizely</strong>.
                         </li>
                     </ul>
                 </div>
-                <hr className="m-.5 border-gray-100" />
+                <hr className="m-.5 border-gray-100 dark:border-gray-800" />
                 <div >
                     <div className="flex items-center mb-2">
                         <img src="/shipsy_logo.jpeg" alt="Shipsy Logo" className="w-7 h-7 mr-2 rounded" />
@@ -27,16 +27,16 @@ const ContactPage: React.FC = () => {
                     <p className="text-sm   italic"><strong>Jan 2025 - May 2025</strong></p>
                     <p className="text-sm  mb-4 italic"><strong> Gurgaon, onsite</strong></p>
                     <ul className="list-disc list-inside mt-2 space-y-1">
-                        <li className="mb-2 text-black md:text-lg md:leading-5 leading-tight">
+                        <li className="mb-2 text-foreground md:text-lg md:leading-5 leading-tight">
                             Developed a comprehensive finance mobile web view UI for <strong>QuipUp</strong>, integrating APIs for riders to access their financial information with adaptable client-specific configurations.
                         </li>
-                        <li className="mb-2 text-black md:text-lg md:leading-5 leading-tight">
-                            Optimized bulk pickup processing by implementing <code className='bg-gray-50 border rounded-sm'>Promise.all</code> for concurrent conflict resolution and database operations, resulting in a <strong>3x speedup</strong> of API performance.
+                        <li className="mb-2 text-foreground md:text-lg md:leading-5 leading-tight">
+                            Optimized bulk pickup processing by implementing <code className='bg-gray-50 dark:bg-gray-800 border rounded-sm'>Promise.all</code> for concurrent conflict resolution and database operations, resulting in a <strong>3x speedup</strong> of API performance.
                         </li>
-                        <li className="mb-2 text-black md:text-lg md:leading-5 leading-tight">
+                        <li className="mb-2 text-foreground md:text-lg md:leading-5 leading-tight">
                             Delivered a <strong>hyper-local phone-exchange module</strong> for Flipkart, enabling doorstep device swaps in <strong>10–15 minutes</strong> through real-time assessment checks.
                         </li>
-                        <li className="mb-2 text-black md:text-lg md:leading-5 leading-tight">
+                        <li className="mb-2 text-foreground md:text-lg md:leading-5 leading-tight">
                             Designed and rolled out an <strong>ad-hoc pickup flow</strong> for Movin that lets riders collect consignments not yet registered in the hub manager&apos;s ops dashboard, eliminating manual entry.
                         </li>
                     </ul>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import "./globals.css";
 import "./font.css";
 import Header from "./_components/header";
-
 // import { Source_Serif_4 } from 'next/font/google'
 import Footer from "./_components/footer";
 import { ThemeProvider } from "@/components/providers/theme-provider";
@@ -37,16 +36,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" >
-      <body className={` px-3 border`} >
-        <div className="flex flex-col min-h-screen " >
-          <div className="flex-grow">
-            <Header />
-            <main className="flex-grow">{children}</main>
+    <html lang="en" suppressHydrationWarning>
+      <body className="px-3 border">
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <div className="flex flex-col min-h-screen">
+            <div className="flex-grow">
+              <Header />
+              <main className="flex-grow">{children}</main>
+            </div>
+            <Footer />
           </div>
-          {/* </ThemeProvider> */}
-          <Footer />
-        </div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <div className="flex items-start justify-between">
         {/* Left: text takes ~2/3 */}
         <div className="w-2/3 pr-4">
-          <div className="text-black text-base leading-tight">
+          <div className="text-foreground text-base leading-tight">
             <span>
               This is the homepage of <span className="font-bold">Aman Sharma</span>.
             </span>
@@ -35,7 +35,7 @@ export default function Home() {
             <br />
             <hr className="m-.5 border-transparent" />
             <span>
-              <span className="font-bold text-[#808080]">Newbie</span> at Codeforces 
+              <span className="font-bold text-[#808080] dark:text-gray-400">Newbie</span> at Codeforces
               <img
                 src="/codeforces_logo.png"
                 alt="Codeforces Logo"

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -44,13 +44,13 @@ const Projects = () => {
           <div className="flex space-x-4 mb-3">
             <a
               href={project.links.live}
-              className="text-indigo-900  underline underline-offset-2"
+              className="text-indigo-900 underline underline-offset-2 dark:text-indigo-300"
             >
               Live
             </a>
             <a
               href={project.links.github}
-              className="text-indigo-900  underline underline-offset-2"
+              className="text-indigo-900 underline underline-offset-2 dark:text-indigo-300"
             >
               Github
             </a>
@@ -59,13 +59,15 @@ const Projects = () => {
             {project.details.map((detail, idx) => (
               <li
                 key={idx}
-                className="mb-2 text-black md:text-lg md:leading-5 leading-tight"
+                className="mb-2 text-foreground md:text-lg md:leading-5 leading-tight"
               >
                 {detail}
               </li>
             ))}
           </ul>
-          {index < projects.length - 1 && <hr className="border-gray-100" />}
+          {index < projects.length - 1 && (
+            <hr className="border-gray-100 dark:border-gray-800" />
+          )}
         </div>
       ))}
     </div>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="text-indigo-900 dark:text-indigo-300"
+    >
+      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- enable dark mode via ThemeProvider
- add theme toggle component in header
- adjust link and text colors for dark theme

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a232892d808325a4567ca82a40ddf3